### PR TITLE
Fix Gmail send

### DIFF
--- a/src/gmail/messages.cr
+++ b/src/gmail/messages.cr
@@ -16,14 +16,14 @@ module Google::Gmail
     # sending a RAW RFC 2822 email: https://developers.google.com/gmail/api/reference/rest/v1/users.messages#Message
     # requires scope: https://www.googleapis.com/auth/gmail.send
     def send_request(user_id : String, email : String)
-      email = Base64.strict_encode(email)
+      email = Base64.urlsafe_encode(email)
 
       HTTP::Request.new(
         "POST",
-        "/upload/gmail/v1/users/#{user_id}/messages/send",
+        "/gmail/v1/users/#{user_id}/messages/send",
         HTTP::Headers{
           "Authorization" => "Bearer #{get_token}",
-          "Content-Type"  => "application/json",
+          "Content-Type"  => "message/rfc822"
         },
         {raw: email}.to_json
       )


### PR DESCRIPTION
I was struggling on how to send emails with Gmail. After a lot of debugging I found out that the Send URI was wrong, as like the Content-Type (message/rfc822). Now it works properly following the current Google API standards.